### PR TITLE
Feature/front/board page

### DIFF
--- a/front/src/components/board/Gather.jsx
+++ b/front/src/components/board/Gather.jsx
@@ -13,37 +13,35 @@ import GatherBox from "./GatherBox";
  * 필터 -> 최신순, 인기순, ...등으로 독서 모임 리스트를 필터링하여 렌더링합니다.
  */
 
-const Wrapper = styled.div`
+const GatherBar = styled.article`
 	font-family: Roboto;
 	font-style: normal;
-	margin-top: 100px; /* 간격 띄우기 */
 
-	h2 {
-		display: inline;
-	}
+	margin-top: 100px;
+	margin-bottom: 40px;
 
-	.gatherFilter {
-		font-family: Roboto;
-		font-style: normal;
-		font-weight: normal;
-		font-size: 20px;
-		line-height: 23px;
-		float: right;
-		letter-spacing: -0.015em;
-	}
-
-	.boardCheckBox {
-		margin: 0px 25px 0px 5px;
-		padding-bottom: 5px;
-		cursor: pointer; /* 클릭시 boardCheckedBox로 변경 + 모집중인 카드만 표시 */
-	}
-
-	.gathers {
-		margin-bottom: 50px;
-	}
+	display: flex;
+	justify-content: space-between;
 `;
 
-const Cards = styled.section`
+const GatherBarText = styled.h2`
+	display: inline-block;
+	font-weight: 500;
+	font-size: 24px;
+	line-height: 28px;
+	display: flex;
+	align-items: center;
+	text-align: center;
+
+	letter-spacing: -0.015em;
+`;
+
+const GatherBarFilter = styled.div`
+	display: flex;
+	justify-content: space-between;
+`;
+
+const Cards = styled.section` /* 독서모임 카드 리스트가 렌더링되는 영역 */
 	display: flex;
 	justify-content: space-between;
 	margin-bottom: 50px;
@@ -52,15 +50,13 @@ const Cards = styled.section`
 const Gather = (props) => {
 	return (
 		<>
-			<Wrapper>
-				<div className="gathers">
-					<h2>N개의 독서 모임</h2>
-					<span className="gatherFilter">
-						<GatherBox />
-						<GatherFilter />
-					</span>
-				</div>
-			</Wrapper>
+			<GatherBar>
+				<GatherBarText>N개의 독서 모임</GatherBarText>
+				<GatherBarFilter>
+					<GatherBox />
+					<GatherFilter />
+				</GatherBarFilter>
+			</GatherBar>
 			<Cards>
 				<GatherCards />
 				<GatherCards />

--- a/front/src/components/board/GatherBox.jsx
+++ b/front/src/components/board/GatherBox.jsx
@@ -5,38 +5,33 @@ import styled from 'styled-components';
  * 모집중 박스 컴포넌트 입니다.
  */
 
-const Wrapper = styled.span`
+const GatherBoxContainer = styled.div`
+  display: flex;
+  align-items: center;
+
+`;
+
+const GatherBoxText = styled.span`
   font-family: Roboto;
   font-style: normal;
   font-weight: normal;
   font-size: 20px;
   line-height: 23px;
+`;
 
-  p { 
-    font-family: Roboto;
-    font-style: normal;
-    font-weight: normal;
-    font-size: 20px;
-    line-height: 23px;
-    display: inline-block;
-    align-items: center;
-    text-align: center;
-  }
-
-  .check {
-    margin: 0px 25px 0px 5px;
-    cursor: pointer;
-  }
+const  GatherBoxIcon = styled.div` /* 수정 예정 - 2021.08.23 */
+  margin: 0px 25px 0px 5px;
+  cursor: pointer; /* 클릭 시, boardCheckedBox.png로 변경! */
 `;
 
 const GatherBox = (props) => {
   return (
-    <Wrapper>
-      <p>모집중</p>  
-      <span className="check">
-        <img className="checkBox" src="assets/images/boardCheckBox.png" alt="checkBox"/>
-      </span>
-    </Wrapper>
+    <GatherBoxContainer>
+      <GatherBoxText>모집중</GatherBoxText>
+      <GatherBoxIcon>
+        <img src="assets/images/boardCheckBox.png" alt="icon.png"/>
+      </GatherBoxIcon>
+    </GatherBoxContainer>
   );
 };
 

--- a/front/src/components/board/GatherBox.jsx
+++ b/front/src/components/board/GatherBox.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import styled from 'styled-components';
+import { Checkbox } from 'antd';
 
 /**
  * 모집중 박스 컴포넌트 입니다.
@@ -19,18 +20,25 @@ const GatherBoxText = styled.span`
   line-height: 23px;
 `;
 
-const  GatherBoxIcon = styled.div` /* 수정 예정 - 2021.08.23 */
+const  GatherBoxIcon = styled(Checkbox)` /* checked상태일 때, 디자인하는 방법? */
   margin: 0px 25px 0px 5px;
-  cursor: pointer; /* 클릭 시, boardCheckedBox.png로 변경! */
+  cursor: pointer;
+
+  .ant-checkbox {
+    border: solid 5px;
+  }
+
+  .ant-checkbox-checked {
+    color: #000000;
+    background-color: #FFFFFF;
+  }
 `;
 
 const GatherBox = (props) => {
   return (
     <GatherBoxContainer>
       <GatherBoxText>모집중</GatherBoxText>
-      <GatherBoxIcon>
-        <img src="assets/images/boardCheckBox.png" alt="icon.png"/>
-      </GatherBoxIcon>
+      <GatherBoxIcon />
     </GatherBoxContainer>
   );
 };

--- a/front/src/components/board/GatherFilter.jsx
+++ b/front/src/components/board/GatherFilter.jsx
@@ -1,5 +1,8 @@
 import React from "react";
 import styled from "styled-components";
+import { Select } from 'antd';
+
+const { Option } = Select;
 
 /**
  * 이 페이지에서만 사용되는 필터 버튼입니다.
@@ -7,47 +10,21 @@ import styled from "styled-components";
  *  최신순, 인기순(==좋아요순) 으로 필터링해서 모든 독서 모임 카드를 렌더링합니다.
  */
 
-const GatherFilterButton = styled.button` /* 수정 예정 2021.08.23 */
-  border: solid 2px #C4C4C4;
-  cursor: pointer; /* 클릭 시, 밑으로 내려가면서 최신순, 좋아요순 표시 ! */
-  padding: 8px;
-`;
-
-const GatherFilterAlignIcon = styled.span`
-  width: 24px;
-  height: 24px;
-  margin: 10px;
-`;
-
-const GatherFilterText = styled.span`
-  font-family: Roboto;
-  font-style: normal;
-  font-weight: normal;
-  font-size: 20px;
-  line-height: 23px;
-  letter-spacing: -0.015em;
-
-  margin-left: 8px;
-`;
-
-const GatherFilterDownIcon = styled.span`
-  width: 15px;
-  height: 8px;
-  margin: 10px 10px 20px 15px;
+const GatherFilterButton = styled(Select)`
+  margin-top: 3px; /* 모집중 필터와 간격 맞추기 ! */
 `;
 
 const GatherFilter = (props) => {
 	return (
-		<GatherFilterButton>
-      <GatherFilterAlignIcon>
-        <img src="assets/images/boardFilterIcon.png" alt="icon.png" />
-      </GatherFilterAlignIcon>
-			<GatherFilterText>최신순</GatherFilterText>
-			<GatherFilterDownIcon>
-        <img src="assets/images/boardDownButton.png" alt="icon.png" />
-      </GatherFilterDownIcon>
-			
-		</GatherFilterButton>
+		<GatherFilterButton defaultValue="최신순" style={{ width: 180 }}>
+      <Option value="최신순">
+        <img src="assets/images/boardFilterIcon.png" alt="icon.png" /> 최신순
+      </Option>
+      <Option value="좋아요순">
+      <img src="assets/images/boardFilterIcon.png" alt="icon.png" /> 좋아요순
+      </Option>
+    </GatherFilterButton>
+    
 	);
 };
 

--- a/front/src/components/board/GatherFilter.jsx
+++ b/front/src/components/board/GatherFilter.jsx
@@ -7,9 +7,19 @@ import styled from "styled-components";
  *  최신순, 인기순(==좋아요순) 으로 필터링해서 모든 독서 모임 카드를 렌더링합니다.
  */
 
-const Wrapper = styled.button`
-  border: solid 1px #C4C4C4;
-  padding: 10px;
+const GatherFilterButton = styled.button` /* 수정 예정 2021.08.23 */
+  border: solid 2px #C4C4C4;
+  cursor: pointer; /* 클릭 시, 밑으로 내려가면서 최신순, 좋아요순 표시 ! */
+  padding: 8px;
+`;
+
+const GatherFilterAlignIcon = styled.span`
+  width: 24px;
+  height: 24px;
+  margin: 10px;
+`;
+
+const GatherFilterText = styled.span`
   font-family: Roboto;
   font-style: normal;
   font-weight: normal;
@@ -17,40 +27,27 @@ const Wrapper = styled.button`
   line-height: 23px;
   letter-spacing: -0.015em;
 
-  .boardFilterIcon {
-    width: 24px;
-    height: 24px;
-  }
+  margin-left: 8px;
+`;
 
-  .boardFilterName {
-    margin-left: 25px;
-    margin-right: 25px;
-  }
-
-  .boardDownButton {
-    width: 15px;
-    height: 8px;
-    margin-bottom: 5px;
-    cursor: pointer; /* 일단 여기만 적용 ... */
-  }
-  .
+const GatherFilterDownIcon = styled.span`
+  width: 15px;
+  height: 8px;
+  margin: 10px 10px 20px 15px;
 `;
 
 const GatherFilter = (props) => {
 	return (
-		<Wrapper>
-			<img
-				src="assets/images/boardFilterIcon.png"
-				alt="icon"
-				className="boardFilterIcon"
-			/>
-			<span className="boardFilterName">최신순</span>
-			<img
-				src="assets/images/boardDownButton.png"
-				alt="button"
-				className="boardDownButton"
-			/>
-		</Wrapper>
+		<GatherFilterButton>
+      <GatherFilterAlignIcon>
+        <img src="assets/images/boardFilterIcon.png" alt="icon.png" />
+      </GatherFilterAlignIcon>
+			<GatherFilterText>최신순</GatherFilterText>
+			<GatherFilterDownIcon>
+        <img src="assets/images/boardDownButton.png" alt="icon.png" />
+      </GatherFilterDownIcon>
+			
+		</GatherFilterButton>
 	);
 };
 

--- a/front/src/components/board/Main.jsx
+++ b/front/src/components/board/Main.jsx
@@ -17,7 +17,6 @@ import Gather from "../board/Gather";
 const Wrapper = styled.section`
 	width: 1200px;
 	margin: 0 auto;
-	//border: solid 1px; /* 임시 */
 `;
 
 const Main = (props) => {

--- a/front/src/components/board/Search.jsx
+++ b/front/src/components/board/Search.jsx
@@ -24,11 +24,21 @@ const SearchLogoText = styled.span`
   margin-left: 8px;
 `;
 
-const ButtonWrapper = styled.div` /* 수정 예정 - 2021.08.23 */
-  margin-top: 15px;
+const BtnSection = styled.article`
+  width: 900px;
+  margin: auto;
+`;
+
+const BtnWrapper = styled.div`
+  margin-top: 30px;
   margin-bottom: 15px;
+  width: auto;
   display: flex;
-  justify-content: center;
+  justify-content: space-around;
+`;
+
+const BtnText = styled.div`
+  width: 120px;
 `;
 
 const Search = (props) => { 
@@ -39,18 +49,36 @@ const Search = (props) => {
         <SearchLogoText>독서 모임 찾기</SearchLogoText> 
       </SearchLogo>
       <SearchBar />
-      <ButtonWrapper>
-        <Button />
-        <Button />
-        <Button />
-        <Button />
-      </ButtonWrapper>
-      <ButtonWrapper>
-        <Button />
-        <Button />
-        <Button />
-        <Button />
-      </ButtonWrapper>
+      <BtnSection>
+        <BtnWrapper>
+          <Button>
+            <BtnText>소수정예</BtnText>
+          </Button>
+          <Button>
+            <BtnText>온라인</BtnText>
+          </Button>
+          <Button>
+            <BtnText>오프라인</BtnText>
+          </Button>
+          <Button>
+            <BtnText>온・오프라인</BtnText>
+          </Button>
+        </BtnWrapper>
+        <BtnWrapper>
+          <Button>
+            <BtnText>수도권</BtnText>
+          </Button>
+          <Button>
+            <BtnText>지방</BtnText>
+          </Button>
+          <Button>
+            <BtnText>친목</BtnText>
+          </Button>
+          <Button>
+            <BtnText>독서 외 활동</BtnText>
+          </Button>
+        </BtnWrapper>
+      </BtnSection>
     </>
   );
 };

--- a/front/src/components/board/Search.jsx
+++ b/front/src/components/board/Search.jsx
@@ -25,7 +25,7 @@ const SearchLogoText = styled.span`
 `;
 
 const BtnSection = styled.article`
-  width: 900px;
+  width: 850px;
   margin: auto;
 `;
 

--- a/front/src/components/board/Search.jsx
+++ b/front/src/components/board/Search.jsx
@@ -7,26 +7,24 @@ import Button from '../common/Button'
  * 독서 모임 찾기 영역입니다.
  * 
  * 여기에서는 원하는 독서 모임의 이름을 검색하여 특정한 독서 모임을 찾을 수 있고, 검색 바 밑에 여러 가지 특정한
- * 버튼(==태그)를 누르면, 그에 맞는 태그들만 필터링해서 렌더링합니다.
+ * 버튼(==태그)를 누르면, 그에 맞는 태그들만 필터링해서 렌더링합니다. ** 최대 3개까지 가능
  */
 
-const Wrapper = styled.div`
-  .searchLogo {
-    font-family: Roboto;
-    font-style: normal;
-    font-weight: bold;
-    font-size: 24px;
-    line-height: 28px;
-    display: flex;
-    justify-content: center;
-  }
-
-  .logo {
-    margin-right: 8px;
-  }
+const SearchLogo = styled.div`
+  font-family: Roboto;
+  font-style: normal;
+  font-weight: bold;
+  font-size: 24px;
+  line-height: 28px;
+  display: flex;
+  justify-content: center;
 `;
 
-const ButtonWrapper = styled.div`
+const SearchLogoText = styled.span`
+  margin-left: 8px;
+`;
+
+const ButtonWrapper = styled.div` /* 수정 예정 - 2021.08.23 */
   margin-top: 15px;
   margin-bottom: 15px;
   display: flex;
@@ -35,10 +33,11 @@ const ButtonWrapper = styled.div`
 
 const Search = (props) => { 
   return (
-    <Wrapper>
-      <div className="searchLogo">
-        <img src="assets/images/boardSearchLogo.png" alt="logo" className="logo" /> 독서 모임 찾기
-      </div>
+    <>
+      <SearchLogo>
+        <img src="assets/images/boardSearchLogo.png" alt="icon.png"/>
+        <SearchLogoText>독서 모임 찾기</SearchLogoText> 
+      </SearchLogo>
       <SearchBar />
       <ButtonWrapper>
         <Button />
@@ -52,7 +51,7 @@ const Search = (props) => {
         <Button />
         <Button />
       </ButtonWrapper>
-    </Wrapper>
+    </>
   );
 };
 

--- a/front/src/components/board/SearchBar.jsx
+++ b/front/src/components/board/SearchBar.jsx
@@ -7,24 +7,27 @@ import styled from "styled-components";
  *  원하는 키워드를 입력하면 입력한 값에 해당하는 독서 모임의 제목을 렌더링해줌.
  */
 
-const Wrapper = styled.div`
+const SearchBarSection = styled.section`
 	display: flex;
 	justify-content: center;
+`;
 
-	.searchBar {
-		width: 588px;
-		height: 48px;
-		border: 1px solid;
+const SearchBarContainer = styled.div`
+	width: 588px;
+	height: 48px;
+	border: 2px solid #959595;
 
-		display: flex;
-		align-items: center;
-		margin-top: 53px;
-		margin-bottom: 25px;
+	display: flex;
+	align-items: center;
+	margin-top: 53px;
+	margin-bottom: 25px;
 
-		letter-spacing: -0.015em;
-	}
+	letter-spacing: -0.015em;
+`;
 
-	.searchInput {
+// styled.input -> 에러 발생, 따라서, styled.div 안에 input {}으로 설정함.
+const SearchBarInput = styled.div`
+	input {
 		border: none;
 		outline: none;
 		width: 540px;
@@ -36,12 +39,14 @@ const Wrapper = styled.div`
 
 const SearchBar = (props) => {
 	return (
-		<Wrapper>
-			<div className="searchBar">
-				<img src="assets/images/search.png" alt="search" className="search" />
-				<input type="text" placeholder="검색" className="searchInput" />
-			</div>
-		</Wrapper>
+		<SearchBarSection>
+			<SearchBarContainer>
+				<img src="assets/images/search.png" alt="icon.png" />
+				<SearchBarInput>
+					<input type="text" placeholder="검색" />
+				</SearchBarInput>
+			</SearchBarContainer>
+		</SearchBarSection>
 	);
 };
 

--- a/front/src/components/board/SearchBar.jsx
+++ b/front/src/components/board/SearchBar.jsx
@@ -20,7 +20,7 @@ const SearchBarContainer = styled.div`
 	display: flex;
 	align-items: center;
 	margin-top: 53px;
-	margin-bottom: 25px;
+	margin-bottom: 40px;
 
 	letter-spacing: -0.015em;
 `;

--- a/front/src/components/common/GatherCards.jsx
+++ b/front/src/components/common/GatherCards.jsx
@@ -15,64 +15,67 @@ import Tags from "../common/Tags";
 
 const { Meta } = Card;
 
-const Wrapper = styled(Card)`
+const GatherCardContainer = styled.article`
 	width: 346px;
 	height: 350px;
 	border: solid 1px #e5e5e5;
 	border-radius: 0px 0px 10px 10px;
+`;
 
-	/* ant-desing 코드 ~~ */
+const GatherCardText = styled(Card)`
 
-	.ant-card-meta-title {
-		/* 독서모임 이름 */
+	.ant-card-meta-title {	/* 독서모임 이름 */
 		font-family: Roboto;
 		font-weight: bold;
 		font-size: 20px;
 		line-height: 36px;
 	}
-	.ant-card-meta-description {
-		/* 한 줄 소개 */
+
+	.ant-card-meta-description {	/* 한 줄 소개 */
 		font-family: Roboto;
 		font-size: 16px;
 		line-height: 36px;
 		color: black;
 		margin-bottom: 15px;
 	}
-
-	/* ~~ ant-desing 코드 */
-
-	.container {
-		/* 하단 */
-		display: flex;
-		justify-content: space-between;
-		align-items: flex-end;
-	}
-
-	.like {
-		display: flex;
-		flex-direction: column;
-		align-items: center;
-		cursor: pointer;
-	}
 `;
+
+const GatherCardBottom = styled.div`
+	display: flex;
+	justify-content: space-between;
+	align-items: flex-end;
+`;
+
+const GatherCardTag = styled.div`
+/*  */
+`;
+
+const GatherCardLike = styled.div`
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	cursor: pointer;
+`
+
 
 const GatherCards = (props) => {
 	return (
-		<Wrapper
-			cover={<img src="assets/images/gatherCardThumbnail.png" alt="images" />}
-		>
-			<Meta title="독서 모임 이름" description="한 줄 소개" />
-			<div className="container">
-				<span className="tags">
-					<Tags />
-					<Tags />
-				</span>
-				<div className="like">
-					<img className="likeButton" src="assets/images/like.png" alt="icon" />
-					<span>9,999</span>
-				</div>
-			</div>
-		</Wrapper>
+		<GatherCardContainer>
+			<GatherCardText
+				cover={<img src="assets/images/gatherCardThumbnail.png" alt="images" />}
+			>
+				<Meta title="독서 모임 이름" description="한 줄 소개" />
+				<GatherCardBottom>
+					<GatherCardTag>
+						<Tags />
+						<Tags />
+					</GatherCardTag>
+					<GatherCardLike>
+						<img src="assets/images/like.png" alt="icon" />9,999
+					</GatherCardLike>
+				</GatherCardBottom>
+			</GatherCardText>
+		</GatherCardContainer>
 	);
 };
 

--- a/front/src/components/common/GatherCards.jsx
+++ b/front/src/components/common/GatherCards.jsx
@@ -29,7 +29,6 @@ const Wrapper = styled(Card)`
 		font-weight: bold;
 		font-size: 20px;
 		line-height: 36px;
-		margin-left: 15px; /* 임시 마진 간격 */
 	}
 	.ant-card-meta-description {
 		/* 한 줄 소개 */
@@ -37,8 +36,7 @@ const Wrapper = styled(Card)`
 		font-size: 16px;
 		line-height: 36px;
 		color: black;
-		margin-bottom: 45px;
-		margin-left: 15px; /* 임시 마진 간격 */
+		margin-bottom: 15px;
 	}
 
 	/* ~~ ant-desing 코드 */
@@ -48,7 +46,6 @@ const Wrapper = styled(Card)`
 		display: flex;
 		justify-content: space-between;
 		align-items: flex-end;
-		margin-left: 15px; /* 임시 마진 간격 */
 	}
 
 	.like {
@@ -56,7 +53,6 @@ const Wrapper = styled(Card)`
 		flex-direction: column;
 		align-items: center;
 		cursor: pointer;
-		margin-right: 15px; /* 임시 마진 간격 */
 	}
 `;
 


### PR DESCRIPTION
develop과 merge한 후, 충돌이 일어나 보드 페이지 UI가 깨져서 레이아웃 수정을 했습니다.

### 변경사항
1. 기존에 JSX 내부의 태그에 className을 부여해서  최상위 styled component 안에서 .className {}로 직접 디자인 했던 것을
        -> 전부 styled componet 로 바꾸고, 컴포넌트 계층을 구조화 하였습니다.
2. 모집중 필터, 리스트 정렬 필터(최신순, 좋아요순)을 ant-design으로 동적으로 수정하였습니다. 
3. gatherCards.jsx의  css를 수정하였습니다.

### 질문사항
- 모집중 필터를 클릭했을 때의 디자을 수정하고 싶은데 어떻게 해야 되는지 잘 모르겠습니다...(사진은 Notion에 첨부하겠습니다.)