### PR TITLE
fix: 로그인 상태에 따른 네비게이션 조건부 렌더링 에러 해결

### DIFF
--- a/front/src/components/common/navBar/NavBar.jsx
+++ b/front/src/components/common/navBar/NavBar.jsx
@@ -4,6 +4,7 @@ import styled from "styled-components";
 import { Modal, Menu, Dropdown } from "antd";
 import Login from "./login/Login";
 import RegisterForm from "../form/RegisterForm";
+import { useEffect } from "react";
 
 const Nav = styled.nav`
 	width: 1200px;
@@ -106,9 +107,19 @@ const StyledDropdownMenu = styled(Menu)`
 
 const NavBar = () => {
 	const [isModalVisible, setIsModalVisible] = useState(false);
-	const [isLoggedIn, setLoggedIn] = useState(null);
-	const [userImage, setUserImage] = useState("");
-	console.log(isLoggedIn);
+	const userId = localStorage.getItem("user_id");
+	const userImg = localStorage.getItem("user_image");
+	const [isLoggedIn, setLoggedIn] = useState(false);
+	const [userImage, setUserImage] = useState(null);
+	console.log("login state: ", isLoggedIn);
+	console.log("userImage: ", userImage);
+
+	useEffect(() => {
+		if (userId) {
+			setLoggedIn(true);
+			setUserImage(userImg);
+		}
+	}, [userId, userImg]);
 
 	const showModal = () => {
 		setIsModalVisible(true);
@@ -118,17 +129,11 @@ const NavBar = () => {
 		setIsModalVisible(false);
 	};
 
-	const getLoginStatus = (userId) => {
-		setLoggedIn(userId);
-	};
-
-	const getUserImage = (image) => {
-		setUserImage(image);
-	};
-
 	const handleLogout = () => {
-		localStorage.removeItem("userId");
-		setLoggedIn(null);
+		localStorage.removeItem("user_id");
+		localStorage.removeItem("user_image");
+		setLoggedIn(false);
+		setUserImage(null);
 	};
 
 	const dropdownMenu = (
@@ -165,11 +170,7 @@ const NavBar = () => {
 									<br />
 									<strong>책무리</strong>에서 모여보세요!
 								</Title>
-								<Login
-									onCancel={handleCancel}
-									getUserImage={getUserImage}
-									getLoginStatus={getLoginStatus}
-								/>
+								<Login onCancel={handleCancel} setLoggedIn={setLoggedIn} />
 							</StyledModal>
 						</NavIcon>
 					</NavMenu>

--- a/front/src/components/common/navBar/login/Login.jsx
+++ b/front/src/components/common/navBar/login/Login.jsx
@@ -38,7 +38,7 @@ const Login = ({ ...props }) => {
 		try {
 			const res = await axios.get(`/users/${googleId}`);
 
-			if (res.status === 204) {
+			if (!res.id) {
 				const user = {
 					id: googleId,
 					name,
@@ -50,9 +50,9 @@ const Login = ({ ...props }) => {
 			}
 
 			console.log(res.data);
-			localStorage.setItem("userId", res.data.id);
-			props.getLoginStatus(localStorage.getItem("userId"));
-			props.getUserImage(res.data.imgUrl);
+
+			localStorage.setItem("user_id", res.data.id);
+			localStorage.setItem("user_image", res.data.imgUrl);
 			props.onCancel();
 			history.push("/");
 


### PR DESCRIPTION
구글로그인으로 받아 온 유저의 아이디와 구글 프로필 이미지를 전역적으로 사용하기 위해 로컬스토리지에서 관리하도록 처리했습니다. 그런데 네비게이션 바 조건부 렌더링은 잘 되나, 페이지를 이동할 때마다 브라우저가 계속 깜빡거립니다. SPA여도 페이지 이동 시에는 깜빡거리는게 정상인가요?