### PR TITLE
chore: 독서모임 좋아요 중복 등록시(FE에서 잘못된 요청 했을 때 400 error 발생)

### DIFF
--- a/back/src/main/java/bookclub/chakmuri/controller/likedclub/LikedClubController.java
+++ b/back/src/main/java/bookclub/chakmuri/controller/likedclub/LikedClubController.java
@@ -1,6 +1,7 @@
 package bookclub.chakmuri.controller.likedclub;
 
 import bookclub.chakmuri.domain.LikedClub;
+import bookclub.chakmuri.repository.LikedClubRepository;
 import bookclub.chakmuri.service.LikedClubService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -17,15 +18,19 @@ import java.util.stream.Collectors;
 public class LikedClubController {
 
     private final LikedClubService likedClubService;
+    private final LikedClubRepository likedClubRepository;
 
     @PostMapping
     public ResponseEntity<LikedClubResponseDto> createLikedClub(
             @RequestBody LikedClubCreateRequestDto likedClubRequestDto) {
-        LikedClub likedClub = likedClubService.createLikedClub(likedClubRequestDto);
-
-        return new ResponseEntity(
-                "정상적으로 등록됐습니다. (likedClubId: " + likedClub.getId() + ")", HttpStatus.OK
-        );
+        try{
+            LikedClub likedClub = likedClubService.createLikedClub(likedClubRequestDto);
+            return new ResponseEntity(
+                    "정상적으로 등록됐습니다. (likedClubId: " + likedClub.getId() + ")", HttpStatus.OK
+            );
+        }catch (Exception e){
+            return new ResponseEntity("이미 등록된 좋아요한 독서모임 입니다.", HttpStatus.BAD_REQUEST);
+        }
     }
 
     @DeleteMapping

--- a/back/src/main/java/bookclub/chakmuri/service/LikedClubService.java
+++ b/back/src/main/java/bookclub/chakmuri/service/LikedClubService.java
@@ -34,6 +34,10 @@ public class LikedClubService {
         final Club club = clubRepository.findById(likedClubRequestDto.getClubId())
                 .orElseThrow();
 
+        if(likedClubRepository.findByClubAndUser(club, user) != null){
+            return null;
+        }
+
         club.changeLikes(club.getLikes() + 1); // 좋아요 버튼 클릭된 상태
 
         LikedClub postLikedClub = LikedClub.builder()


### PR DESCRIPTION
독서모임 좋아요, 좋아요 취소를 FE 측에서 해결해야 하나 혹시 FE에서 잘못된 api를 호출할 경우를 대비해
400 error를 발생시키는 로직을 추가하였음