### PR TITLE
Feature/back/member register

### DIFF
--- a/back/build.gradle
+++ b/back/build.gradle
@@ -19,6 +19,7 @@ repositories {
 }
 
 dependencies {
+	implementation 'org.springframework.boot:spring-boot-starter-mail'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
@@ -27,6 +28,7 @@ dependencies {
 //   implementation 'com.googlecode.json-simple:json-simple:1.1.1'
 	implementation group: 'org.springframework.cloud', name: 'spring-cloud-starter-aws', version: '2.2.6.RELEASE'
 	compileOnly 'org.projectlombok:lombok'
+	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	runtimeOnly 'mysql:mysql-connector-java'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/back/src/main/java/bookclub/chakmuri/controller/club/ClubController.java
+++ b/back/src/main/java/bookclub/chakmuri/controller/club/ClubController.java
@@ -43,7 +43,7 @@ public class ClubController {
     }
 
 
-    //독서모임 리스트 조회(검색조건 x)
+    //독서모임 리스트 조회
     @GetMapping
     public ResponseEntity<ClubPageResponseDto> getClubs(
             @RequestParam(value = "sortBy") String sortBy,

--- a/back/src/main/java/bookclub/chakmuri/controller/likedclub/LikedClubController.java
+++ b/back/src/main/java/bookclub/chakmuri/controller/likedclub/LikedClubController.java
@@ -18,7 +18,6 @@ import java.util.stream.Collectors;
 public class LikedClubController {
 
     private final LikedClubService likedClubService;
-    private final LikedClubRepository likedClubRepository;
 
     @PostMapping
     public ResponseEntity<LikedClubResponseDto> createLikedClub(

--- a/back/src/main/java/bookclub/chakmuri/controller/member/JoingClubPageResponse.java
+++ b/back/src/main/java/bookclub/chakmuri/controller/member/JoingClubPageResponse.java
@@ -1,0 +1,4 @@
+package bookclub.chakmuri.controller.member;
+
+public class JoingClubPageResponse {
+}

--- a/back/src/main/java/bookclub/chakmuri/controller/member/JoiningClubResponse.java
+++ b/back/src/main/java/bookclub/chakmuri/controller/member/JoiningClubResponse.java
@@ -1,0 +1,4 @@
+package bookclub.chakmuri.controller.member;
+
+public class JoiningClubResponse {
+}

--- a/back/src/main/java/bookclub/chakmuri/controller/member/MemberController.java
+++ b/back/src/main/java/bookclub/chakmuri/controller/member/MemberController.java
@@ -52,7 +52,7 @@ public class MemberController {
 //        return new ResponseEntity("참여가 승인되었습니다.", HttpStatus.OK);
 //    }
 
-//    승인 대기자 목록 조회, 참여자 목록 조회 (approvalStatus: WAITING -> 승인대기자, COMFIRMED -> 참여자)
+    //승인 대기자 목록 조회, 참여자 목록 조회 (approvalStatus: WAITING -> 승인대기자, COMFIRMED -> 참여자)
     @GetMapping("/users/{userId}")
     public ResponseEntity<MemberPageResponseDto> getMembers(
             @PathVariable("userId") String userId,

--- a/back/src/main/java/bookclub/chakmuri/controller/member/MemberController.java
+++ b/back/src/main/java/bookclub/chakmuri/controller/member/MemberController.java
@@ -38,29 +38,29 @@ public class MemberController {
     }
 
     //참여 승인 -> 참여중인 독서모임에 추가, 참여 신청자에게 메일(승인되었습니다)
-    @PutMapping
-    public ResponseEntity<MemberResponseDto> memberApprove(
-            @RequestParam("clubId") Long clubId,
-            @RequestParam("userId") String userId){
-        memberService.approveMember(clubId, userId);
-        return new ResponseEntity("참여가 승인되었습니다.", HttpStatus.OK);
-    }
+//    @PutMapping
+//    public ResponseEntity<MemberResponseDto> memberApprove(
+//            @RequestParam("clubId") Long clubId,
+//            @RequestParam("userId") String userId){
+//        memberService.approveMember(clubId, userId);
+//        return new ResponseEntity("참여가 승인되었습니다.", HttpStatus.OK);
+//    }
 
     //승인 대기자 목록 조회, 참여자 목록 조회 (approvalStatus: WAITING -> 승인대기자, COMFIRMED -> 참여자)
-    @GetMapping("/clubs/{clubId}")
-    public ResponseEntity<MemberPageResponseDto> getMembers(
-            @PathVariable("clubId") Long clubId,
-            @RequestParam("approvalStatus") String approvalStatus,
-            @RequestParam("page") int page){
-        Page<Member> allMembers = memberService.getMemberList(clubId, approvalStatus, page);
-        Long totalCount = allMembers.getTotalElements();
-        List<MemberResponseDto> response = allMembers
-                .stream()
-                .map(MemberResponseDto::new)
-                .collect(Collectors.toList());
-        MemberPageResponseDto memberPageResponseDto = new MemberPageResponseDto(totalCount, response);
-        return new ResponseEntity(memberPageResponseDto, HttpStatus.OK);
-    }
+//    @GetMapping("/clubs/{clubId}")
+//    public ResponseEntity<MemberPageResponseDto> getMembers(
+//            @PathVariable("clubId") Long clubId,
+//            @RequestParam("approvalStatus") String approvalStatus,
+//            @RequestParam("page") int page){
+//        Page<Member> allMembers = memberService.getMemberList(clubId, approvalStatus, page);
+//        Long totalCount = allMembers.getTotalElements();
+//        List<MemberResponseDto> response = allMembers
+//                .stream()
+//                .map(MemberResponseDto::new)
+//                .collect(Collectors.toList());
+//        MemberPageResponseDto memberPageResponseDto = new MemberPageResponseDto(totalCount, response);
+//        return new ResponseEntity(memberPageResponseDto, HttpStatus.OK);
+//    }
 
     //참여중인 독서모임 조회
 }

--- a/back/src/main/java/bookclub/chakmuri/controller/member/MemberController.java
+++ b/back/src/main/java/bookclub/chakmuri/controller/member/MemberController.java
@@ -30,10 +30,11 @@ public class MemberController {
     }
 
     //참여신청 취소, 참여신청 거절, 참여자 내보내기 -> 참여신청자에게 메일(거절/ 내보내기)
-    @DeleteMapping("/users/{userId}")
+    @DeleteMapping
     public ResponseEntity<MemberResponseDto> memberCancel(
-            @PathVariable String userId){
-        memberService.deleteMember(userId);
+            @RequestParam String userId,
+            @RequestParam Long clubId){
+        memberService.deleteMember(userId, clubId);
         return new ResponseEntity("독서모임 참여가 취소되었습니다.", HttpStatus.OK);
     }
 

--- a/back/src/main/java/bookclub/chakmuri/controller/member/MemberController.java
+++ b/back/src/main/java/bookclub/chakmuri/controller/member/MemberController.java
@@ -1,33 +1,66 @@
 package bookclub.chakmuri.controller.member;
 
+import bookclub.chakmuri.controller.likedclub.LikedClubPageResponseDto;
+import bookclub.chakmuri.controller.likedclub.LikedClubResponseDto;
+import bookclub.chakmuri.domain.ApprovalStatus;
 import bookclub.chakmuri.domain.Member;
 import bookclub.chakmuri.service.MemberService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 @RestController
 @RequestMapping("/members")
 @RequiredArgsConstructor
 public class MemberController {
 
-    private MemberService memberService;
+    private final MemberService memberService;
 
-    //참여신청, 참여신청 취소
+    //참여신청 -> 독서모임장에게 메일
     @PostMapping
-    public ResponseEntity memberApply(
+    public ResponseEntity<MemberResponseDto> memberApply(
             @RequestBody MemberCreateRequestDto memberCreateRequestDto) {
         Member member = memberService.apply(memberCreateRequestDto);
-        return new ResponseEntity(member.toString(), HttpStatus.OK);
+        return new ResponseEntity("참여신청이 완료되었습니다.", HttpStatus.OK);
     }
 
-    //참여 승인
+    //참여신청 취소, 참여신청 거절, 참여자 내보내기 -> 참여신청자에게 메일(거절/ 내보내기)
+    @DeleteMapping("/users/{userId}")
+    public ResponseEntity<MemberResponseDto> memberCancel(
+            @PathVariable String userId){
+        memberService.deleteMember(userId);
+        return new ResponseEntity("독서모임 참여가 취소되었습니다.", HttpStatus.OK);
+    }
 
-    //참여 거절, 참여자 내보내기
+    //참여 승인 -> 참여중인 독서모임에 추가, 참여 신청자에게 메일(승인되었습니다)
+    @PutMapping
+    public ResponseEntity<MemberResponseDto> memberApprove(
+            @RequestParam("clubId") Long clubId,
+            @RequestParam("userId") String userId){
+        memberService.approveMember(clubId, userId);
+        return new ResponseEntity("참여가 승인되었습니다.", HttpStatus.OK);
+    }
 
-    //참여중인 독서모임에 추가
+    //승인 대기자 목록 조회, 참여자 목록 조회 (approvalStatus: WAITING -> 승인대기자, COMFIRMED -> 참여자)
+    @GetMapping("/clubs/{clubId}")
+    public ResponseEntity<MemberPageResponseDto> getMembers(
+            @PathVariable("clubId") Long clubId,
+            @RequestParam("approvalStatus") String approvalStatus,
+            @RequestParam("page") int page){
+        Page<Member> allMembers = memberService.getMemberList(clubId, approvalStatus, page);
+        Long totalCount = allMembers.getTotalElements();
+        List<MemberResponseDto> response = allMembers
+                .stream()
+                .map(MemberResponseDto::new)
+                .collect(Collectors.toList());
+        MemberPageResponseDto memberPageResponseDto = new MemberPageResponseDto(totalCount, response);
+        return new ResponseEntity(memberPageResponseDto, HttpStatus.OK);
+    }
+
+    //참여중인 독서모임 조회
 }

--- a/back/src/main/java/bookclub/chakmuri/controller/member/MemberController.java
+++ b/back/src/main/java/bookclub/chakmuri/controller/member/MemberController.java
@@ -3,6 +3,7 @@ package bookclub.chakmuri.controller.member;
 import bookclub.chakmuri.controller.likedclub.LikedClubPageResponseDto;
 import bookclub.chakmuri.controller.likedclub.LikedClubResponseDto;
 import bookclub.chakmuri.domain.ApprovalStatus;
+import bookclub.chakmuri.domain.LikedClub;
 import bookclub.chakmuri.domain.Member;
 import bookclub.chakmuri.service.MemberService;
 import lombok.RequiredArgsConstructor;
@@ -25,8 +26,12 @@ public class MemberController {
     @PostMapping
     public ResponseEntity<MemberResponseDto> memberApply(
             @RequestBody MemberCreateRequestDto memberCreateRequestDto) {
-        Member member = memberService.apply(memberCreateRequestDto);
-        return new ResponseEntity("참여신청이 완료되었습니다.", HttpStatus.OK);
+        try{
+            Member member = memberService.apply(memberCreateRequestDto);
+            return new ResponseEntity("참여신청이 완료되었습니다. (memberId : " + member.getId() + ")", HttpStatus.OK);
+        }catch (Exception e){
+            return new ResponseEntity("이미 참여신청된 독서모임 입니다.", HttpStatus.BAD_REQUEST);
+        }
     }
 
     //참여신청 취소, 참여신청 거절, 참여자 내보내기 -> 참여신청자에게 메일(거절/ 내보내기)

--- a/back/src/main/java/bookclub/chakmuri/controller/member/MemberController.java
+++ b/back/src/main/java/bookclub/chakmuri/controller/member/MemberController.java
@@ -47,21 +47,21 @@ public class MemberController {
 //        return new ResponseEntity("참여가 승인되었습니다.", HttpStatus.OK);
 //    }
 
-    //승인 대기자 목록 조회, 참여자 목록 조회 (approvalStatus: WAITING -> 승인대기자, COMFIRMED -> 참여자)
-//    @GetMapping("/clubs/{clubId}")
-//    public ResponseEntity<MemberPageResponseDto> getMembers(
-//            @PathVariable("clubId") Long clubId,
-//            @RequestParam("approvalStatus") String approvalStatus,
-//            @RequestParam("page") int page){
-//        Page<Member> allMembers = memberService.getMemberList(clubId, approvalStatus, page);
-//        Long totalCount = allMembers.getTotalElements();
-//        List<MemberResponseDto> response = allMembers
-//                .stream()
-//                .map(MemberResponseDto::new)
-//                .collect(Collectors.toList());
-//        MemberPageResponseDto memberPageResponseDto = new MemberPageResponseDto(totalCount, response);
-//        return new ResponseEntity(memberPageResponseDto, HttpStatus.OK);
-//    }
+//    승인 대기자 목록 조회, 참여자 목록 조회 (approvalStatus: WAITING -> 승인대기자, COMFIRMED -> 참여자)
+    @GetMapping("/users/{userId}")
+    public ResponseEntity<MemberPageResponseDto> getMembers(
+            @PathVariable("userId") String userId,
+            @RequestParam("approvalStatus") String approvalStatus,
+            @RequestParam("page") int page){
+        Page<Member> allMembers = memberService.getMemberList(userId, approvalStatus, page);
+        Long totalCount = allMembers.getTotalElements();
+        List<MemberResponseDto> response = allMembers
+                .stream()
+                .map(MemberResponseDto::new)
+                .collect(Collectors.toList());
+        MemberPageResponseDto memberPageResponseDto = new MemberPageResponseDto(totalCount, response);
+        return new ResponseEntity(memberPageResponseDto, HttpStatus.OK);
+    }
 
     //참여중인 독서모임 조회
 }

--- a/back/src/main/java/bookclub/chakmuri/controller/member/MemberCreateRequestDto.java
+++ b/back/src/main/java/bookclub/chakmuri/controller/member/MemberCreateRequestDto.java
@@ -11,11 +11,4 @@ public class MemberCreateRequestDto {
 
     private String userId;
     private Long clubId;
-    private ApprovalStatus approvalStatus;
-
-    public Member toEntity(){
-        return Member.builder()
-                .approvalStatus(approvalStatus)
-                .build();
-    }
 }

--- a/back/src/main/java/bookclub/chakmuri/controller/member/MemberPageResponseDto.java
+++ b/back/src/main/java/bookclub/chakmuri/controller/member/MemberPageResponseDto.java
@@ -1,0 +1,4 @@
+package bookclub.chakmuri.controller.member;
+
+public class MemberPageResponseDto {
+}

--- a/back/src/main/java/bookclub/chakmuri/controller/member/MemberPageResponseDto.java
+++ b/back/src/main/java/bookclub/chakmuri/controller/member/MemberPageResponseDto.java
@@ -1,4 +1,21 @@
 package bookclub.chakmuri.controller.member;
 
+import bookclub.chakmuri.controller.club.ClubResponseDto;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.List;
+
+@Getter
+@Setter
+@NoArgsConstructor
 public class MemberPageResponseDto {
+    private Long totalCount;
+    private List<MemberResponseDto> memberList;
+
+    public MemberPageResponseDto(Long totalCount, List<MemberResponseDto> memberList){
+        this.totalCount = totalCount;
+        this.memberList = memberList;
+    }
 }

--- a/back/src/main/java/bookclub/chakmuri/controller/member/MemberResponseDto.java
+++ b/back/src/main/java/bookclub/chakmuri/controller/member/MemberResponseDto.java
@@ -1,4 +1,24 @@
 package bookclub.chakmuri.controller.member;
 
+import bookclub.chakmuri.domain.ApprovalStatus;
+import bookclub.chakmuri.domain.Member;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.springframework.beans.BeanUtils;
+
+@Getter
+@Setter
+@NoArgsConstructor
 public class MemberResponseDto {
+    private Long id;
+    private Long clubId;
+    private String userId;
+    private ApprovalStatus approvalStatus;
+
+    public MemberResponseDto(Member member) {
+        BeanUtils.copyProperties(member, this);
+        this.clubId = member.getClub().getId();
+        this.userId = member.getUser().getId();
+    }
 }

--- a/back/src/main/java/bookclub/chakmuri/domain/Member.java
+++ b/back/src/main/java/bookclub/chakmuri/domain/Member.java
@@ -21,11 +21,11 @@ public class Member {
     private Long id;
 
     @JoinColumn(name = "user_id")
-    @ManyToOne(fetch = LAZY, cascade = CascadeType.ALL)
+    @ManyToOne(fetch = LAZY)
     private User user;
 
     @JoinColumn(name = "club_id")
-    @ManyToOne(fetch = LAZY, cascade = CascadeType.ALL)
+    @ManyToOne(fetch = LAZY)
     private Club club;
 
     @Column(nullable = false)

--- a/back/src/main/java/bookclub/chakmuri/repository/MemberRepository.java
+++ b/back/src/main/java/bookclub/chakmuri/repository/MemberRepository.java
@@ -1,9 +1,14 @@
 package bookclub.chakmuri.repository;
 
+import bookclub.chakmuri.domain.Club;
 import bookclub.chakmuri.domain.Member;
+import bookclub.chakmuri.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface MemberRepository extends JpaRepository<Member, Long> {
+    Optional<Member> findByUserAndClub(User user, Club club);
 }

--- a/back/src/main/java/bookclub/chakmuri/repository/MemberRepository.java
+++ b/back/src/main/java/bookclub/chakmuri/repository/MemberRepository.java
@@ -1,8 +1,11 @@
 package bookclub.chakmuri.repository;
 
+import bookclub.chakmuri.domain.ApprovalStatus;
 import bookclub.chakmuri.domain.Club;
 import bookclub.chakmuri.domain.Member;
 import bookclub.chakmuri.domain.User;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -11,4 +14,6 @@ import java.util.Optional;
 @Repository
 public interface MemberRepository extends JpaRepository<Member, Long> {
     Optional<Member> findByUserAndClub(User user, Club club);
+
+    Page<Member> findByUserAndApprovalStatus(User user, ApprovalStatus approvalStatus, Pageable pageable);
 }

--- a/back/src/main/java/bookclub/chakmuri/service/MemberService.java
+++ b/back/src/main/java/bookclub/chakmuri/service/MemberService.java
@@ -25,7 +25,6 @@ public class MemberService {
     private final UserRepository userRepository;
     private final ClubRepository clubRepository;
 
-    //TODO: LikedClubRepositoryCustom 설정 후 applyId 생성 작업
     @Transactional
     public Member apply(MemberCreateRequestDto request){
         User user = userRepository.findById(request.getUserId()).orElseThrow();

--- a/back/src/main/java/bookclub/chakmuri/service/MemberService.java
+++ b/back/src/main/java/bookclub/chakmuri/service/MemberService.java
@@ -11,6 +11,8 @@ import bookclub.chakmuri.repository.MemberRepository;
 import bookclub.chakmuri.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -40,8 +42,15 @@ public class MemberService {
         memberRepository.delete(member);
     }
 
-//    public Page<Member> getMemberList(Long clubId, String approvalStauts, int page){
-//        Club club = clubRepository.findById(clubId).orElseThrow();
-//
-//    }
+    public Page<Member> getMemberList(String userId, String approvalStatus, int page){
+        User user = userRepository.findById(userId).orElseThrow();
+        PageRequest pageRequest = PageRequest.of((page - 1), 3, Sort.by(Sort.Direction.DESC, "id"));
+        ApprovalStatus status;
+        if(!approvalStatus.equals(ApprovalStatus.CONFIRMED.toString())){
+            status = ApprovalStatus.WAITING;
+        }else {
+            status = ApprovalStatus.CONFIRMED;
+        }
+        return memberRepository.findByUserAndApprovalStatus(user, status, pageRequest);
+    }
 }

--- a/back/src/main/java/bookclub/chakmuri/service/MemberService.java
+++ b/back/src/main/java/bookclub/chakmuri/service/MemberService.java
@@ -1,6 +1,7 @@
 package bookclub.chakmuri.service;
 
 import bookclub.chakmuri.controller.member.MemberCreateRequestDto;
+import bookclub.chakmuri.domain.ApprovalStatus;
 import bookclub.chakmuri.domain.Club;
 import bookclub.chakmuri.domain.Member;
 import bookclub.chakmuri.domain.User;
@@ -9,6 +10,7 @@ import bookclub.chakmuri.repository.LikedClubRepository;
 import bookclub.chakmuri.repository.MemberRepository;
 import bookclub.chakmuri.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -23,22 +25,20 @@ public class MemberService {
 
     //TODO: LikedClubRepositoryCustom 설정 후 applyId 생성 작업
     @Transactional
-    public Member apply(MemberCreateRequestDto memberCreateRequestDto){
-        final Member newMember = convertToMember(memberCreateRequestDto.toEntity(),
-                memberCreateRequestDto.getUserId(),
-                memberCreateRequestDto.getClubId());
-        return memberRepository.save(newMember);
+    public Member apply(MemberCreateRequestDto request){
+        User user = userRepository.findById(request.getUserId()).orElseThrow();
+        Club club = clubRepository.findById(request.getClubId()).orElseThrow();
+        Member member = Member.builder().user(user).club(club).approvalStatus(ApprovalStatus.WAITING).build();
+        return memberRepository.save(member);
     }
 
-    private Member convertToMember(Member member, String userId, Long clubId){
-        User user = userRepository.findById(userId)
-                .orElseThrow(); // TODO: UserNotFoundException
-        Club club = clubRepository.findById(clubId)
-                .orElseThrow(); // TODO: ClubNotFoundException
-        return member.builder()
-                .user(user)
-                .club(club)
-                .approvalStatus(member.getApprovalStatus())
-                .build();
+    @Transactional
+    public void deleteMember(String userId){
+
     }
+
+//    public Page<Member> getMemberList(Long clubId, String approvalStauts, int page){
+//        Club club = clubRepository.findById(clubId).orElseThrow();
+//
+//    }
 }

--- a/back/src/main/java/bookclub/chakmuri/service/MemberService.java
+++ b/back/src/main/java/bookclub/chakmuri/service/MemberService.java
@@ -33,8 +33,11 @@ public class MemberService {
     }
 
     @Transactional
-    public void deleteMember(String userId){
-
+    public void deleteMember(String userId, Long clubId){
+        User user = userRepository.findById(userId).orElseThrow();
+        Club club = clubRepository.findById(clubId).orElseThrow();
+        Member member = memberRepository.findByUserAndClub(user, club).orElseThrow();
+        memberRepository.delete(member);
     }
 
 //    public Page<Member> getMemberList(Long clubId, String approvalStauts, int page){

--- a/back/src/main/java/bookclub/chakmuri/service/MemberService.java
+++ b/back/src/main/java/bookclub/chakmuri/service/MemberService.java
@@ -30,6 +30,11 @@ public class MemberService {
     public Member apply(MemberCreateRequestDto request){
         User user = userRepository.findById(request.getUserId()).orElseThrow();
         Club club = clubRepository.findById(request.getClubId()).orElseThrow();
+
+        if(memberRepository.findByUserAndClub(user, club).isPresent()){
+            return null;
+        }
+
         Member member = Member.builder().user(user).club(club).approvalStatus(ApprovalStatus.WAITING).build();
         return memberRepository.save(member);
     }

--- a/back/src/main/resources/application.yml
+++ b/back/src/main/resources/application.yml
@@ -20,6 +20,9 @@ spring:
       pageable:
         one-indexed-parameters: true
 
+# 메일 서비스
+#  mail: host: smtp.gmail.com port: 587 username: password: properties: mail: smtp: auth: true starttls: enable : true
+
 logging:
   level:
     org:


### PR DESCRIPTION
- 참여자 목록
    - 참여자 목록을 보여준다. → 승인 대기자 목록 보여주는 기능까지 한꺼번에 처리
    - 내보내기 버튼을 누르면 내보내진 참여자에게 메일이 전송된다. → **aws SES 기능 사용할 예정**
- 참여신청
    - 참여신청 버튼을 클릭하면 참여신청 성공 모달 창이 발생하고 마이페이지의 '참여중인 모임' 리스트에 신청한 모임이 추가된다. → 참여중인 모임 리스트에 추가되도록 구현하진 않았고, 참여 신청자가 member 테이블 내에 들어감. 참여중인 모임 리스트 조회는 다른 팀원이 분담
    - 모집이 마감되면 버튼이 비활성화된다. → FE측 기능(BE에서는 enddate만 반환)
    - 이미 참여신청을 한 상태라면 참여취소 버튼으로 변경되어 기존의 참여신청을 취소할 수 있다. → 취소 기능 구현 완료 (참여신청 취소, 참여신청 거절, 참여자 내보내기 모두가 같은 api 사용하므로 고민이 필요함)