### PR TITLE
참여중인 독서모임 기능 구현

### DIFF
--- a/back/src/main/java/bookclub/chakmuri/controller/likedclub/LikedClubResponseDto.java
+++ b/back/src/main/java/bookclub/chakmuri/controller/likedclub/LikedClubResponseDto.java
@@ -19,7 +19,7 @@ public class LikedClubResponseDto {
     private String title;               //독서모임 이름
     private String contents;            //독서모임 한줄소개
     private String imgUrl;              //독서모임 썸네일 이미지
-    private LocalDate startDate;        //독서모임 시작일
+    private LocalDate endDate;        //독서모임 시작일
     private String tags;                //독서모임 태그
     private int likes;                  //독서모임 좋아요 수
     private ClubStatus clubStatus;      //독서모임 모집여부
@@ -31,7 +31,7 @@ public class LikedClubResponseDto {
         this.title = likedClub.getClub().getTitle();
         this.contents = likedClub.getClub().getContents();
         this.imgUrl = likedClub.getClub().getImgUrl();
-        this.startDate = likedClub.getClub().getStartDate();
+        this.endDate = likedClub.getClub().getEndDate();
         this.tags = likedClub.getClub().getTags();
         this.likes = likedClub.getClub().getLikes();
         this.clubStatus = likedClub.getClub().getClubStatus();

--- a/back/src/main/java/bookclub/chakmuri/controller/member/JoiningClubPageResponse.java
+++ b/back/src/main/java/bookclub/chakmuri/controller/member/JoiningClubPageResponse.java
@@ -1,0 +1,22 @@
+package bookclub.chakmuri.controller.member;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class JoiningClubPageResponse {
+    private Long totalCount;
+    private LocalDateTime createdAt;
+    private List<JoiningClubResponse> joingClubList;
+
+    public JoiningClubPageResponse(Long totalCount, List<JoiningClubResponse> joingClubList) {
+        this.totalCount = totalCount;
+        this.joingClubList = joingClubList;
+    }
+}

--- a/back/src/main/java/bookclub/chakmuri/controller/member/JoiningClubResponse.java
+++ b/back/src/main/java/bookclub/chakmuri/controller/member/JoiningClubResponse.java
@@ -1,4 +1,43 @@
 package bookclub.chakmuri.controller.member;
 
+import bookclub.chakmuri.domain.Club;
+import bookclub.chakmuri.domain.ClubStatus;
+import bookclub.chakmuri.domain.Member;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.springframework.beans.BeanUtils;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@NoArgsConstructor
 public class JoiningClubResponse {
+    /**
+     * "id": 1,
+     *       "clubId": 1,
+     *       "title": "스프링부트",
+     *       "contents": "스프링부트 공부 모임",
+     *       "imgUrl": null,
+     *       "endDate": "2021-08-31",
+     *       "tags": "온라인, 친목",
+     *       "likes": 2,
+     *       "clubStatus": "ACTIVE"
+     */
+    private Long id;
+    private String title;
+    private String contents;
+    private String imgUrl;
+    private LocalDate endDate; //
+    private String tags;
+    private Long likes;
+    private ClubStatus clubStatus; //
+
+    public JoiningClubResponse(Club club) {
+        BeanUtils.copyProperties(club, this);
+
+    }
+
 }

--- a/back/src/main/java/bookclub/chakmuri/controller/member/MemberController.java
+++ b/back/src/main/java/bookclub/chakmuri/controller/member/MemberController.java
@@ -1,9 +1,6 @@
 package bookclub.chakmuri.controller.member;
 
-import bookclub.chakmuri.controller.likedclub.LikedClubPageResponseDto;
-import bookclub.chakmuri.controller.likedclub.LikedClubResponseDto;
-import bookclub.chakmuri.domain.ApprovalStatus;
-import bookclub.chakmuri.domain.LikedClub;
+import bookclub.chakmuri.domain.Club;
 import bookclub.chakmuri.domain.Member;
 import bookclub.chakmuri.service.MemberService;
 import lombok.RequiredArgsConstructor;
@@ -69,4 +66,25 @@ public class MemberController {
     }
 
     //참여중인 독서모임 조회
+    /**
+     * - 참여중인 독서모임 → 마감/Dday → 마감 라벨 적용 ex) D-4, D-1, 마감
+     * - 참여중인 독서모임에 좋아요 클릭 → 내가 좋아요한 독서모임에도 등록 (좋아요 링크) -> API 재활용
+     */
+    @GetMapping("/users/{userId}")
+    public ResponseEntity<JoiningClubPageResponse> getJoingClubs(
+            @PathVariable("userId") String userId,
+            @RequestParam("approvalStatus") String approvalStatus,
+            @RequestParam("page") int page) {
+        Page<Club> allJoingClubs = memberService.getJoingClubList(userId, approvalStatus, page);
+        if(allJoingClubs == null) {
+            return new ResponseEntity("참여중인 독서모임이 없습니다.", HttpStatus.OK);
+        }
+        Long totalCount = allJoingClubs.getTotalElements();
+        List<JoiningClubResponse> response = allJoingClubs
+                .stream()
+                .map(JoiningClubResponse::new)
+                .collect(Collectors.toList());
+        JoiningClubPageResponse joiningClubPageResponse = new JoiningClubPageResponse(totalCount, response);
+        return new ResponseEntity(joiningClubPageResponse, HttpStatus.OK);
+    }
 }

--- a/back/src/main/java/bookclub/chakmuri/repository/MemberRepository.java
+++ b/back/src/main/java/bookclub/chakmuri/repository/MemberRepository.java
@@ -16,4 +16,6 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     Optional<Member> findByUserAndClub(User user, Club club);
 
     Page<Member> findByUserAndApprovalStatus(User user, ApprovalStatus approvalStatus, Pageable pageable);
+
+    Page<Club> findAllByClub(Club club, Pageable pageable);
 }

--- a/back/src/main/java/bookclub/chakmuri/service/MemberService.java
+++ b/back/src/main/java/bookclub/chakmuri/service/MemberService.java
@@ -16,6 +16,8 @@ import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Optional;
+
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -56,5 +58,17 @@ public class MemberService {
             status = ApprovalStatus.CONFIRMED;
         }
         return memberRepository.findByUserAndApprovalStatus(user, status, pageRequest);
+    }
+
+    public Page<Club> getJoingClubList(String userId, String approvalStatus, int page) {
+        User user = userRepository.findById(userId).orElseThrow();
+        Club club = clubRepository.findByUser(user).orElseThrow();
+        PageRequest pageRequest = PageRequest.of((page - 1), 3, Sort.by(Sort.Direction.DESC, "id"));
+
+        if(approvalStatus.equals(ApprovalStatus.CONFIRMED.toString())) {
+            return memberRepository.findAllByClub(club, pageRequest);
+        } else {
+            return null;
+        }
     }
 }


### PR DESCRIPTION
- 참여중인 독서모임 중 마감된 독서모임에는 마감 라벨을 붙인다. (endDate기준)
- 참여중인 독서모임 중 D-7부터 D-day 라벨을 붙인다. → 7일 이하에 대한 조건문은 FE
- 참여중인 독서모임에 좋아요 아이콘을 누르면 내가 좋아요한 독서모임에 추가된다.
   → API 재활용 고려

- 승인 대기자 리스트를 보여준다. (check) → 태영님이랑 공통부분이라 처리하신듯하다.
- 승인 및 거절 버튼을 누르면 결과에 따라 참여신청자에게 메일이 전송된다. --->Mail API를 조금 더 공부해보고 오늘 저녁까지 마무리 지어보겠습니다.